### PR TITLE
Fix chromeOS deep-link action string

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId 'com.runsignup.rdtiming'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 20
-        versionName "1.0.8"
+        versionCode 22
+        versionName "1.0.9"
     }
     splits {
         abi {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-feature android:name="android.hardware.camera" android:required="false"/>
+  <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/android/app/src/main/java/com/runsignup/rdtiming/MainActivity.java
+++ b/android/app/src/main/java/com/runsignup/rdtiming/MainActivity.java
@@ -1,5 +1,7 @@
 package com.runsignup.rdtiming;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 

--- a/android/app/src/main/java/com/runsignup/rdtiming/MainActivity.java
+++ b/android/app/src/main/java/com/runsignup/rdtiming/MainActivity.java
@@ -19,6 +19,17 @@ public class MainActivity extends ReactActivity {
     super.onCreate(null);
   }
 
+  @Override
+  public void onNewIntent(Intent intent) {
+    //on chromeOS, app links get created with the action "org.chromium.arc.intent.action.VIEW" instead of "android.intent.action.VIEW".
+    //Change the action to the correct thing that RN is expecting.
+    if(intent.getAction().equals("org.chromium.arc.intent.action.VIEW")){
+      super.onNewIntent(new Intent(intent).setAction(Intent.ACTION_VIEW));
+    } else {
+      super.onNewIntent(intent);
+    }
+  }
+
   /**
    * Returns the name of the main component registered from JavaScript.
    * This is used to schedule rendering of the component.

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Mobile Timing",
     "slug": "rdtiming",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "orientation": "portrait",
     "icon": "./src/assets/icon.png",
     "primaryColor": "#00AC65",
@@ -20,12 +20,12 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.runsignup.rdtiming",
-      "buildNumber": "4"
+      "buildNumber": "1"
     },
     "android": {
       "icon": "./src/assets/icon.png",
       "package": "com.runsignup.rdtiming",
-      "versionCode": 20
+      "versionCode": 22
     },
     "extra": {
       "bugsnag": {

--- a/ios/MobileTiming/Info.plist
+++ b/ios/MobileTiming/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.8</string>
+    <string>1.0.9</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -31,7 +31,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>1</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Closes #41 

I really went down the rabbit-hole on this one, but it ended up being a really simple fix once I narrowed down the issue. Turns out chromeOS handles deep links incorrectly (in my opinion). When we're done with the authorization flow, we have a redirect URL that the web browser redirects to, in our case `com.rsu.mobile-timing-app://?code=` followed by the oauth code. In chromeOS (and android), it knows that the `com.rsu.mobile-timing-app` scheme is associated with our app, so it creates a new intent with the action `android.intent.action.VIEW` and the url in the intent's data. However, on chromeOS, the action is `org.chromium.arc.intent.action.VIEW`, which RN is not expecting to see to pass along to the javascript side.

Anyway, I need you guys to test to make sure it totally works. As part of trying to figure all of this out, my local copy is now on hermes, I upgraded a ton of packages and had to re-export the expo prebuild stuff, root the android subsystem on my pixelbook, and a ton of other stuff. It shouldn't affect this change though.